### PR TITLE
feat: ツイート投稿に画像添付を対応、新TweetDtoおよび表示ロジックを追加

### DIFF
--- a/src/components/MyTweetContainer.vue
+++ b/src/components/MyTweetContainer.vue
@@ -1,129 +1,75 @@
 <template>
-    <div v-for="myTweet in myTweets" :key="myTweet.id" class="tweet">
-      <div class="tweet-element name">{{ myTweet.name }}</div>
-      <div class="tweet-element text">{{ myTweet.text }}</div>
-      <div class="tweet-element date">{{ myTweet.created }}</div>
-      <div class="tweet-element">
-        <button @click="deleteTweet(myTweet.id)">削除</button>
-      </div>
-    </div>
-  </template>
+  <div class="tweet-wrapper">
+    <TweetItem
+      v-for="myTweet in myTweets"
+      :key="myTweet.id"
+      :tweet="myTweet"
+    >
+      <template #default>
+        <button class="delete-button" @click="deleteTweet(myTweet.id)">削除</button>
+      </template>
+    </TweetItem>
+  </div>
+</template>
   
-  <script setup>
-  import { useAuthStore } from '../stores/auth';
-  import { onMounted, ref } from 'vue';
-  
-  const authStore = useAuthStore();
-  const myTweets = ref([]);
-  
-  const loadMyTweets = async () => {
-    const params = { user_id: authStore.userId };
-    const query = new URLSearchParams(params);
-    const response = await fetch(`${process.env["VUE_APP_API_HOST_URL"]}/api/tweets/user?${query}`, {
-      credentials: 'include'
-    });
-  
-    const json = await response.json();
-    myTweets.value = json;
-  };
-  
-  const deleteTweet = async (id) => {
-    const params = { tweet_id: id };
-    const query = new URLSearchParams(params);
-  
-    await fetch(`${process.env["VUE_APP_API_HOST_URL"]}/api/tweets?${query}`, {
-      method: 'DELETE',
-      credentials: 'include'
-    });
-  
-    loadMyTweets();
-  };
-  
-  onMounted(loadMyTweets);
-  </script>
+<script setup>
+import { useAuthStore } from '../stores/auth';
+import { onMounted, ref } from 'vue';
+
+import TweetItem from './TweetItem.vue';
+
+const apiHostUrl = process.env.VUE_APP_API_HOST_URL;
+const authStore = useAuthStore();
+const myTweets = ref([]);
+
+const loadMyTweets = async () => {
+  const params = { user_id: authStore.userId };
+  const query = new URLSearchParams(params);
+  const response = await fetch(`${apiHostUrl}/api/tweets/user?${query}`, {
+    credentials: 'include'
+  });
+
+  const json = await response.json();
+  myTweets.value = json;
+};
+
+const deleteTweet = async (id) => {
+  const params = { tweet_id: id };
+  const query = new URLSearchParams(params);
+
+  await fetch(`${apiHostUrl}/api/tweets?${query}`, {
+    method: 'DELETE',
+    credentials: 'include'
+  });
+
+  loadMyTweets();
+};
+
+onMounted(loadMyTweets);
+</script>
     
     <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-
-.tweet {
-    background-color: rgba(255, 255, 255, 0.8);
-    /* 背景色を半透明の白に */
-    border-radius: 10px;
-    /* 角を丸くする */
-    padding: 10px 20px;
-    /* 内側の余白 */
-    margin-bottom: 10px;
-    /* ツイート間のスペース */
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-    /* 影を追加 */
-    display: flex;
-    align-items: center;
-    transition: transform 0.2s;
-    /* ホバー時のアニメーション */
+/* 削除ボタンのスタイル */
+.delete-button {
+    background-color: #007acc; /* ボタンの背景色 */
+    color: white;              /* 文字色 */
+    border: none;              /* ボーダーなし */
+    padding: 5px 10px;         /* 内側の余白 */
+    border-radius: 5px;        /* 角を丸く */
+    font-size: 0.9em;          /* 文字サイズ調整 */
+    cursor: pointer;           /* カーソルをポインタに */
+    transition: background-color 0.3s; /* ホバー時の変化 */
+    margin-left: auto;         /* 右寄せ（必要に応じて） */
 }
 
-.tweet:hover {
-    transform: scale(1.02);
-    /* ホバー時に少し拡大 */
+.delete-button:hover {
+    background-color: #005f99; /* ホバー時の背景色 */
 }
 
-.tweet-element {
-    margin-right: 20px;
-    /* 各要素の間にスペースを追加 */
-    font-family: 'Arial', sans-serif;
-    /* フォントを変更 */
-    color: #333;
-    /* 文字色を濃い灰色に */
+.tweet-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
-
-.tweet-element.name {
-    font-weight: bold;
-    /* 名前を太字に */
-    font-size: 1.2em;
-    /* フォントサイズを大きく */
-    color: #007acc;
-    /* 色を変更 */
-    flex: 1;
-}
-
-.tweet-element.text {
-    font-size: 1em;
-    /* フォントサイズ */
-    color: #333;
-    /* 色を濃い灰色に */
-    flex: 2;
-}
-
-.tweet-element.date {
-    font-size: 0.9em;
-    /* フォントサイズを小さく */
-    color: #777;
-    /* 色を薄い灰色に */
-    flex: 1;
-    text-align: right;
-    /* 右揃え */
-}
-
-button {
-    background-color: #007acc;
-    /* ボタンの背景色 */
-    color: white;
-    /* ボタンの文字色 */
-    border: none;
-    /* ボーダーをなしに */
-    padding: 5px 10px;
-    /* 内側の余白 */
-    border-radius: 5px;
-    /* 角を丸くする */
-    cursor: pointer;
-    /* カーソルをポインタに */
-    transition: background-color 0.3s;
-    /* 背景色変更のアニメーション */
-}
-
-button:hover {
-    background-color: #005f99;
-    /* ホバー時の背景色 */
-}
-
 </style>

--- a/src/components/TweetContainer.vue
+++ b/src/components/TweetContainer.vue
@@ -14,8 +14,6 @@ import { onMounted } from 'vue';
 
 import TweetItem from './TweetItem.vue';
 
-const apiHostUrl = process.env.VUE_APP_API_HOST_URL;
-
 onMounted(useTweetStore().loadTweets);
 </script>
     

--- a/src/components/TweetContainer.vue
+++ b/src/components/TweetContainer.vue
@@ -1,101 +1,30 @@
 <template>
-    <div v-for="tweet in useTweetStore().tweets" v-bind:key="tweet" class="tweet">
-        <div class="tweet-element name">{{ tweet.name }}</div>
-        <div class="tweet-element text">{{ tweet.text }}</div>
-        <div class="tweet-element date">{{ tweet.created }}</div>
-    </div>
+  <div class="tweet-wrapper">
+    <TweetItem
+      v-for="tweet in useTweetStore().tweets"
+      :key="tweet.id"
+      :tweet="tweet"
+    />
+  </div>
 </template>
     
 <script setup>
 import { useTweetStore } from '../stores/tweet'
 import { onMounted } from 'vue';
 
+import TweetItem from './TweetItem.vue';
+
+const apiHostUrl = process.env.VUE_APP_API_HOST_URL;
+
 onMounted(useTweetStore().loadTweets);
 </script>
     
     <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-
-.tweet {
-    background-color: rgba(255, 255, 255, 0.8);
-    /* 背景色を半透明の白に */
-    border-radius: 10px;
-    /* 角を丸くする */
-    padding: 10px 20px;
-    /* 内側の余白 */
-    margin-bottom: 10px;
-    /* ツイート間のスペース */
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-    /* 影を追加 */
-    display: flex;
-    align-items: center;
-    transition: transform 0.2s;
-    /* ホバー時のアニメーション */
+.tweet-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
-
-.tweet:hover {
-    transform: scale(1.02);
-    /* ホバー時に少し拡大 */
-}
-
-.tweet-element {
-    margin-right: 20px;
-    /* 各要素の間にスペースを追加 */
-    font-family: 'Arial', sans-serif;
-    /* フォントを変更 */
-    color: #333;
-    /* 文字色を濃い灰色に */
-}
-
-.tweet-element.name {
-    font-weight: bold;
-    /* 名前を太字に */
-    font-size: 1.2em;
-    /* フォントサイズを大きく */
-    color: #007acc;
-    /* 色を変更 */
-    flex: 1;
-}
-
-.tweet-element.text {
-    font-size: 1em;
-    /* フォントサイズ */
-    color: #333;
-    /* 色を濃い灰色に */
-    flex: 2;
-}
-
-.tweet-element.date {
-    font-size: 0.9em;
-    /* フォントサイズを小さく */
-    color: #777;
-    /* 色を薄い灰色に */
-    flex: 1;
-    text-align: right;
-    /* 右揃え */
-}
-
-button {
-    background-color: #007acc;
-    /* ボタンの背景色 */
-    color: white;
-    /* ボタンの文字色 */
-    border: none;
-    /* ボーダーをなしに */
-    padding: 5px 10px;
-    /* 内側の余白 */
-    border-radius: 5px;
-    /* 角を丸くする */
-    cursor: pointer;
-    /* カーソルをポインタに */
-    transition: background-color 0.3s;
-    /* 背景色変更のアニメーション */
-}
-
-button:hover {
-    background-color: #005f99;
-    /* ホバー時の背景色 */
-}
-
 </style>
-    
+ 

--- a/src/components/TweetForm.vue
+++ b/src/components/TweetForm.vue
@@ -1,12 +1,15 @@
 <template>
-    <form id="tweet-form" v-on:submit.prevent="putTweet">
-        <textarea id="tweet-text" placeholder="Tweetを投稿してください" v-model="tweetText"
-            :disabled="!authStore.isAuthenticated"></textarea>
-        <button type="submit" :disabled="!authStore.isAuthenticated">Tweet</button>
-        <p v-if="!authStore.isAuthenticated" class="login-message">
-            投稿するには <router-link to="/login-form" class="login-link">ログイン</router-link> してください。
-        </p>
+  <div class="tweet-form-wrapper">
+    <form id="tweet-form" v-on:submit.prevent="putTweet" enctype="multipart/form-data">
+      <textarea id="tweet-text" placeholder="Tweetを投稿してください" v-model="tweetText"
+        :disabled="!authStore.isAuthenticated"></textarea>
+      <input type="file" multiple @change="handleFiles" :disabled="!authStore.isAuthenticated" />
+      <button type="submit" :disabled="!authStore.isAuthenticated">Tweet</button>
+      <p v-if="!authStore.isAuthenticated" class="login-message">
+        投稿するには <router-link to="/login-form" class="login-link">ログイン</router-link> してください。
+      </p>
     </form>
+  </div>
 </template>
 
 <script setup>
@@ -16,106 +19,118 @@ import { ref } from 'vue';
 
 const authStore = useAuthStore();
 const tweetText = ref('');
+const files = ref([]);
+
+const handleFiles = (event) => {
+    files.value = Array.from(event.target.files);
+    console.log(files.value)
+};
 
 const putTweet = async () => {
-    if (tweetText.value.trim() !== '') {
-        await createTweet(tweetText.value);
-        tweetText.value = '';
-        useTweetStore().loadTweets();
-    }
+    if (tweetText.value.trim() === '' && files.value.length === 0) return;
+
+    const formData = new FormData();
+    formData.append('userId', authStore.userId);
+    formData.append('text', tweetText.value);
+
+    files.value.forEach(file => {
+        formData.append('mediaFiles', file);
+    });
+
+    for (const [key, value] of formData.entries()) {
+  console.log(`${key}:`, value);
 }
 
-async function createTweet(message) {
-    console.log(message);
 
-    const data = {
-        // userId: useUserStore().userId,
-        userId: authStore.userId,
-        text: message
-    };
-    console.log(data);
-    console.log(JSON.stringify(data));
-
-    const response = await fetch(`${process.env["VUE_APP_API_HOST_URL"]}/api/tweets`, {
+    await fetch(`${process.env["VUE_APP_API_HOST_URL"]}/api/tweets`, {
         method: 'POST',
-        headers: {
-            'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(data),
+        body: formData,
         credentials: "include"
     });
-    console.log(response);
-}
+
+    tweetText.value = '';
+    files.value = [];
+    useTweetStore().loadTweets();
+};
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
+.tweet-form-wrapper {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  padding: 0 10px;
+}
+
 #tweet-form {
-    background-color: #e0f7fa;
-    /* 背景色を半透明の白に */
-    border-radius: 0 0 10px 10px;
-    /* 角を丸くする */
-    padding: 20px;
-    /* 内側の余白 */
-    margin: 0 0 20px 0;
-    /* 上下の余白 */
+  max-width: 600px;
+  width: 100%;
+  border-radius: 10px 10px 10px 10px;
+  /* 角を丸くする */
+  padding: 20px;
+  /* 内側の余白 */
+  margin: 0 0 20px 0;
+  /* 上下の余白 */
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+   /* 軽いシャドウ */
 }
 
 #tweet-text {
-    width: 100%;
-    /* 幅を100%に */
-    height: 80px;
-    /* 高さを80pxに */
-    border-radius: 5px;
-    /* 角を丸くする */
-    padding: 10px;
-    /* 内側の余白 */
-    border: 1px solid #ccc;
-    /* ボーダー */
-    font-family: 'Arial', sans-serif;
-    /* フォントを変更 */
-    font-size: 1em;
-    /* フォントサイズを調整 */
-    resize: none;
-    /* リサイズを無効に */
-    box-sizing: border-box;
-    /* パディングとボーダーを含むボックスサイズ */
+  width: 100%;
+  /* 幅を100%に */
+  height: 80px;
+  /* 高さを80pxに */
+  border-radius: 5px;
+  /* 角を丸くする */
+  padding: 10px;
+  /* 内側の余白 */
+  border: 1px solid #ccc;
+  /* ボーダー */
+  font-family: 'Arial', sans-serif;
+  /* フォントを変更 */
+  font-size: 1em;
+  /* フォントサイズを調整 */
+  resize: none;
+  /* リサイズを無効に */
+  box-sizing: border-box;
+  /* パディングとボーダーを含むボックスサイズ */
 }
 
 #tweet-text::placeholder {
-    color: #999;
-    /* プレースホルダーの色 */
+  color: #999;
+  /* プレースホルダーの色 */
 }
 
 #tweet-form button {
-    background-color: #007acc;
-    /* ボタンの背景色 */
-    color: white;
-    /* ボタンの文字色 */
-    border: none;
-    /* ボーダーをなしに */
-    padding: 10px 20px;
-    /* 内側の余白 */
-    border-radius: 5px;
-    /* 角を丸くする */
-    cursor: pointer;
-    /* カーソルをポインタに */
-    transition: background-color 0.3s;
-    /* 背景色変更のアニメーション */
-    font-family: 'Arial', sans-serif;
-    /* フォントを変更 */
-    font-size: 1em;
-    /* フォントサイズを調整 */
-    display: block;
-    margin: 10px auto 0;
-    /* 中央揃え */
-    width: auto;
-    /* 幅を自動に */
+  background-color: #007acc;
+  /* ボタンの背景色 */
+  color: white;
+  /* ボタンの文字色 */
+  border: none;
+  /* ボーダーをなしに */
+  padding: 10px 20px;
+  /* 内側の余白 */
+  border-radius: 5px;
+  /* 角を丸くする */
+  cursor: pointer;
+  /* カーソルをポインタに */
+  transition: background-color 0.3s;
+  /* 背景色変更のアニメーション */
+  font-family: 'Arial', sans-serif;
+  /* フォントを変更 */
+  font-size: 1em;
+  /* フォントサイズを調整 */
+  display: block;
+  margin: 10px auto 0;
+  /* 中央揃え */
+  width: auto;
+  /* 幅を自動に */
 }
 
 #tweet-form button:hover {
-    background-color: #005f99;
-    /* ホバー時の背景色 */
+  background-color: #005f99;
+  /* ホバー時の背景色 */
 }
 
 #tweet-form button:disabled:hover {

--- a/src/components/TweetItem.vue
+++ b/src/components/TweetItem.vue
@@ -1,0 +1,98 @@
+<template>
+  <div class="tweet">
+    <div class="tweet-element name">{{ tweet.name }}</div>
+    <div class="tweet-element text">{{ tweet.text }}</div>
+    <div class="tweet-element images" v-if="tweet.mediaIds && tweet.mediaIds.length > 0">
+      <img
+        v-for="mediaId in tweet.mediaIds"
+        :key="mediaId"
+        :src="`${apiHostUrl}/api/media/${mediaId}`"
+        alt="Tweet media"
+        class="tweet-image"
+      />
+    </div>
+    <div class="tweet-element footer-row">
+      <div class="tweet-element date">{{ tweet.created }}</div>
+      <slot></slot>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { defineProps } from 'vue';
+
+defineProps({
+  tweet: {
+    type: Object,
+    required: true
+  }
+});
+
+const apiHostUrl = process.env.VUE_APP_API_HOST_URL;
+</script>
+
+<style scoped>
+.tweet {
+  width: 100%;
+  max-width: 600px;
+  background-color: rgba(255, 255, 255, 0.8);
+  border-radius: 10px;
+  padding: 10px 20px;
+  margin-bottom: 10px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.2s;
+  box-sizing: border-box;
+}
+
+.tweet:hover {
+  transform: scale(1.02);
+}
+
+.tweet-element {
+  margin-right: 20px;
+  font-family: 'Arial', sans-serif;
+  color: #333;
+}
+
+.tweet-element.name {
+  font-weight: bold;
+  font-size: 1.2em;
+  color: #007acc;
+  flex: 1;
+}
+
+.tweet-element.text {
+  font-size: 1em;
+  flex: 2;
+}
+
+.tweet-element.date {
+  font-size: 0.9em;
+  color: #777;
+  flex: 1;
+  /* text-align: right; */
+}
+
+.tweet-element.images {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+
+.tweet-image {
+  max-width: 200px;
+  max-height: 200px;
+  margin-right: 10px;
+  border-radius: 5px;
+  object-fit: cover;
+}
+
+.footer-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 10px;
+}
+</style>


### PR DESCRIPTION
- Tweet に関連する Media エンティティを追加し、画像ファイルの保存に対応
- multipart/form-data によるメディア付きツイート投稿を新規にサポート
- TweetService に saveTweetWithMedia を追加し、MediaRepository 経由でバイナリ保存
- TweetDto に mediaIds フィールドを追加し、フロントへ画像IDを提供
- API `/api/tweets` の POST を multipart 形式に変更
- TweetRepository の JPQL を廃止し、エンティティごとの取得に変更（mediaList含むため）
- MediaController で `/api/media/{id}` による画像取得APIを提供（公開）
- TweetItem.vue を作成し、Tweet 表示を共通コンポーネント化、画像表示に対応
- TweetContainer.vue / MyTweetContainer.vue をリファクタリングし、TweetItem を使用
- TweetForm.vue を更新し、画像アップロードフィールドおよび FormData に対応
- changelog に media テーブル追加を反映